### PR TITLE
Fix Settings frame close

### DIFF
--- a/src/dtk.py
+++ b/src/dtk.py
@@ -404,7 +404,7 @@ class EditSettingsFrame(wx.Dialog):
         #self.accelerateDevEnableCheckBox.SetValue(dtkglobal.accelerateDevEnableSetting)
         #Accelerate end
 
-
+        self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
         self.mainSizer.SetEmptyCellSize((0, 0))
         self.Layout()
         self.Fit()


### PR DESCRIPTION
When closing the Settings Frame by pressing the top right cross and then exiting DTK, the Settings frame is not actually destroyed so when trying to open DTK again, the "An instance of the application is already running" error appears.

Added line to actually destroy the Settings frame when closing