### PR TITLE
Show std errors

### DIFF
--- a/src/dtkdeploy.py
+++ b/src/dtkdeploy.py
@@ -543,6 +543,9 @@ class ScriptDataPanel(wx.Panel):
         proc = subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
         )
+        for line in proc.stderr:
+            lineStr = line.decode()
+            wx.CallAfter(self.OnText, lineStr)
         for line in proc.stdout:
             lineStr = line.decode()
             if "jobid:  " in lineStr:
@@ -2482,6 +2485,9 @@ If this field is blank the default test level used is NoTestRun."""
         proc = subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
         )
+        for line in proc.stderr:
+            lineStr = line.decode()
+            wx.CallAfter(self.OnText, lineStr)
         for line in proc.stdout:
             lineStr = line.decode()
             if "jobid:  " in lineStr:

--- a/src/dtkdeploy.py
+++ b/src/dtkdeploy.py
@@ -2436,6 +2436,9 @@ If this field is blank the default test level used is NoTestRun."""
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " + testLevel + " " + "-w" + " " + waitParam]
+        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
+            cmd.remove("-l")
+            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:

--- a/src/dtkdeploy.py
+++ b/src/dtkdeploy.py
@@ -497,6 +497,9 @@ class ScriptDataPanel(wx.Panel):
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]
+        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
+            cmd.remove("-l")
+            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:

--- a/src/dtkdeploy.py
+++ b/src/dtkdeploy.py
@@ -524,9 +524,6 @@ class ScriptDataPanel(wx.Panel):
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]
-        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
-            cmd.remove("-l")
-            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:
@@ -2466,9 +2463,6 @@ If this field is blank the default test level used is NoTestRun."""
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " + testLevel + " " + "-w" + " " + waitParam]
-        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
-            cmd.remove("-l")
-            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:

--- a/src/dtkdeployAccelerate.py
+++ b/src/dtkdeployAccelerate.py
@@ -569,6 +569,9 @@ class ScriptDataPanel(wx.Panel):
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]
+        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
+            cmd.remove("-l")
+            cmd.remove(testLevel)    
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:
@@ -2944,6 +2947,9 @@ class DeployMetadataPanel(wx.Panel):
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " + testLevel + " " + "-w" + " " + waitParam]
+        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
+            cmd.remove("-l")
+            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:

--- a/src/dtkdeployAccelerate.py
+++ b/src/dtkdeployAccelerate.py
@@ -595,10 +595,7 @@ class ScriptDataPanel(wx.Panel):
             waitParam
         ]
         if (platform.system() != "Windows"):
-            cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]
-        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
-            cmd.remove("-l")
-            cmd.remove(testLevel)    
+            cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]  
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:
@@ -2986,9 +2983,6 @@ class DeployMetadataPanel(wx.Panel):
         ]
         if (platform.system() != "Windows"):
             cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " + testLevel + " " + "-w" + " " + waitParam]
-        if (testLevel == 'NoTestRun' and sdbxName == 'Prod'):
-            cmd.remove("-l")
-            cmd.remove(testLevel)
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:

--- a/src/dtkdeployAccelerate.py
+++ b/src/dtkdeployAccelerate.py
@@ -595,7 +595,7 @@ class ScriptDataPanel(wx.Panel):
             waitParam
         ]
         if (platform.system() != "Windows"):
-            cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]  
+            cmd = ["/usr/local/bin/sfdx" + " " + "force:mdapi:deploy" + " " + "--apiversion" + " " + dtkglobal.defaultApiVersion + " " + "-u" + " " + targetName + " " + "-l" + " " +  testLevel + " " + "-w" + " " +  waitParam]
         if checkOnly:
             cmd.append("-c")
         if ignoreWarnings:


### PR DESCRIPTION
Std errors are not displayed when performing a deploy. If any error, the log is stuck at "Start deployment...", but actually it is not doing anything. With this change, the error message is included within the log so the user is at least aware of the failing operation.

![image](https://user-images.githubusercontent.com/7022995/115145175-87235680-a050-11eb-95d5-48894c4302ad.png)
